### PR TITLE
Show Address on QR Code Address Verification Pop-up

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
@@ -51,6 +51,7 @@
 				<div id="verify_address_qr_code" class="hidden">
 					<h1>Scan to Verify Address on Your Device</h1><br>
 					<div id="verify_address_qr_code_container"></div><br>
+					<p>{{ wallet.address }}</p><br>
 					<p>
 							Specter can verify this address if you scan it.<br>
 							It has an address index included in the QR code.


### PR DESCRIPTION
Device screen shows the address after QR code is scanned, but would be good to confirm the address is the same at the screen pop-up (human readable). I was not able to test the change locally, but it seems pretty straightforward so I opened this PR.